### PR TITLE
Delete gestures.mk

### DIFF
--- a/product/gestures.mk
+++ b/product/gestures.mk
@@ -1,3 +1,0 @@
-# CMActions
-PRODUCT_PACKAGES += \
-    CMActions


### PR DESCRIPTION
We already have lenovo doze, resulting in two section of settings for the same stuff (doze/gestures).

Also, having two doze packages might cause conflicts.